### PR TITLE
Add explicit self identifier for measureBlock call

### DIFF
--- a/YamlTests/ExampleTests.swift
+++ b/YamlTests/ExampleTests.swift
@@ -451,7 +451,7 @@ class ExampleTests: XCTestCase {
   
   func testPerformanceExample() {
     self.measureBlock() {
-      Yaml.load(exampleYaml)
+      Yaml.load(self.exampleYaml)
     }
   }
   


### PR DESCRIPTION
And add an EOF newline to the file, apparently.

This change is to fix a carthage build failure after upgrading to XCode 7.1:

.../Carthage/Checkouts/YamlSwift/YamlTests/ExampleTests.swift:454:17: error: reference to property 'exampleYaml' in closure requires explicit 'self.' to make capture semantics explicit