### PR TITLE
increased compatibility

### DIFF
--- a/Yaml/Operators.swift
+++ b/Yaml/Operators.swift
@@ -8,5 +8,10 @@ func count<T:CollectionType>(collection: T) -> T.Index.Distance {
 }
 
 func count(string: String) -> String.Index.Distance {
-    return string.characters.count
+    return string.count
+}
+extension String {
+  var count : String.Index.Distance {
+    return self.characters.count
+  }
 }

--- a/Yaml/Regex.swift
+++ b/Yaml/Regex.swift
@@ -95,11 +95,6 @@ func splitTrail (regex: NSRegularExpression) -> String
       }
 }
 
-func substringWithRange (range: NSRange) -> String -> String {
-  return { string in
-    return (string as NSString).substringWithRange(range)
-  }
-}
 extension String {
   subscript(toIndex index:String.Index) -> String {
     return self[self.startIndex...index]

--- a/Yaml/Regex.swift
+++ b/Yaml/Regex.swift
@@ -34,17 +34,6 @@ let regexOptions: [Character: NSRegularExpressionOptions] = [
   "m": .AnchorsMatchLines
 ]
 
-func replace (regex: NSRegularExpression, template: String) -> String
-    -> String {
-      return { string in
-        let s = NSMutableString(string: string)
-        let range = NSMakeRange(0, string.utf16.count)
-        regex.replaceMatchesInString(s, options: [], range: range,
-            withTemplate: template)
-        return s as String
-      }
-}
-
 extension String {
   func replace (expression: String, with: String) -> String {
     var split = self.componentsSeparatedByString(expression)

--- a/Yaml/Regex.swift
+++ b/Yaml/Regex.swift
@@ -36,7 +36,7 @@ let regexOptions: [Character: NSRegularExpressionOptions] = [
 
 extension String {
   func replace (expression: String, with: String) -> String {
-    var split = self.componentsSeparatedByString(expression)
+    let split = self.componentsSeparatedByString(expression)
     var newString = split[0]
     for i in 1...(split.count-1) {
       newString += with + split[i]

--- a/Yaml/Regex.swift
+++ b/Yaml/Regex.swift
@@ -74,8 +74,8 @@ func splitLead (regex: NSRegularExpression) -> String
         if r.location == NSNotFound {
           return ("", string)
         } else {
-          let s = string as NSString
-          let i = r.location + r.length
+          let s = string
+          let i = string.startIndex.advancedBy(r.location + r.length)
           return (s.substringToIndex(i), s.substringFromIndex(i))
         }
       }

--- a/Yaml/Regex.swift
+++ b/Yaml/Regex.swift
@@ -45,6 +45,17 @@ func replace (regex: NSRegularExpression, template: String) -> String
       }
 }
 
+extension String {
+  func replace (expression: String, with: String) -> String {
+    var split = self.componentsSeparatedByString(expression)
+    var newString = split[0]
+    for i in 1...(split.count-1) {
+      newString += with + split[i]
+    }
+    return newString
+  }
+}
+
 func replace (regex: NSRegularExpression, block: [String] -> String)
     -> String -> String {
       return { string in

--- a/Yaml/Regex.swift
+++ b/Yaml/Regex.swift
@@ -100,15 +100,11 @@ func substringWithRange (range: NSRange) -> String -> String {
     return (string as NSString).substringWithRange(range)
   }
 }
-
-func substringFromIndex (index: Int) -> String -> String {
-  return { string in
-    return (string as NSString).substringFromIndex(index)
+extension String {
+  subscript(toIndex index:String.Index) -> String {
+    return self[self.startIndex...index]
   }
-}
-
-func substringToIndex (index: Int) -> String -> String {
-  return { string in
-    return (string as NSString).substringToIndex(index)
+  subscript(fromIndex index:String.Index) -> String {
+    return self[index...self.endIndex.predecessor()]
   }
 }

--- a/Yaml/Regex.swift
+++ b/Yaml/Regex.swift
@@ -36,12 +36,13 @@ let regexOptions: [Character: NSRegularExpressionOptions] = [
 
 extension String {
   func replace (expression: String, with: String) -> String {
-    let split = self.componentsSeparatedByString(expression)
-    var newString = split[0]
-    for i in 1...(split.count-1) {
-      newString += with + split[i]
+    return self
+      .componentsSeparatedByString(expression)
+      .reduce("") {
+        $1 == ""
+        ? $0 + $1
+        : $0 + with + $1
     }
-    return newString
   }
 }
 

--- a/Yaml/Regex.swift
+++ b/Yaml/Regex.swift
@@ -38,11 +38,7 @@ extension String {
   func replace (expression: String, with: String) -> String {
     return self
       .componentsSeparatedByString(expression)
-      .reduce("") {
-        $1 == ""
-        ? $0 + $1
-        : $0 + with + $1
-    }
+      .joinWithSeparator(with)
   }
 }
 

--- a/Yaml/Tokenizer.swift
+++ b/Yaml/Tokenizer.swift
@@ -226,7 +226,7 @@ func tokenize (text: String) -> Result<[TokenMatch]> {
             }
             let s = text |> substringWithRange(range)
             block += "\n" +
-                replace(regex("^\(bBreak)[ \\t]*|[ \\t]+$"), template: "")(s)
+                s.replace("^\(bBreak)[ \\t]*|[ \\t]+$", with: "")
             text = text |> substringFromIndex(range.location + range.length)
           }
           matchList.append(TokenMatch(.String, block))

--- a/Yaml/Tokenizer.swift
+++ b/Yaml/Tokenizer.swift
@@ -109,9 +109,9 @@ let tokenPatterns: [TokenPattern] = [
 func escapeErrorContext (text: String) -> String {
   let endIndex = text.startIndex.advancedBy(50, limit: text.endIndex)
   let escaped = text.substringToIndex(endIndex)
-      |> replace(regex("\\r"), template: "\\\\r")
-      |> replace(regex("\\n"), template: "\\\\n")
-      |> replace(regex("\""), template: "\\\\\"")
+      .replace("\\r", with: "\\\\r")
+      .replace("\\n", with: "\\\\n")
+      .replace("\"" , with: "\\\\\"")
   return "near \"\(escaped)\""
 }
 
@@ -200,9 +200,9 @@ func tokenize (text: String) -> Result<[TokenMatch]> {
           let (lead, rest) = text |> splitLead(blockPattern)
           text = rest
           let block = (lead
-              |> replace(regex("^\(bBreak)"), template: "")
-              |> replace(regex("^ {0,\(lastIndent)}"), template: "")
-              |> replace(regex("\(bBreak) {0,\(lastIndent)}"), template: "\n")
+              .replace("^\(bBreak)", with: "")
+              .replace("^ {0,\(lastIndent)}", with: "")
+              .replace("\(bBreak) {0,\(lastIndent)}", with: "\n")
             ) + (matches(text, regex: regex("^\(bBreak)")) && lead.endIndex > lead.startIndex
               ? "\n" : "")
           matchList.append(TokenMatch(.String, block))
@@ -217,7 +217,7 @@ func tokenize (text: String) -> Result<[TokenMatch]> {
               "\(plainOutPattern))(?=\(bBreak)|$)"))
           var block = text
                 |> substringWithRange(range)
-                |> replace(regex("^[ \\t]+|[ \\t]+$"), template: "")
+                .replace("^[ \\t]+|[ \\t]+$", with: "")
           text = text |> substringFromIndex(rangeEnd)
           while true {
             let range = matchRange(text, regex: blockPattern)
@@ -235,7 +235,7 @@ func tokenize (text: String) -> Result<[TokenMatch]> {
         case .StringFI:
           let match = text
                 |> substringWithRange(range)
-                |> replace(regex("^[ \\t]|[ \\t]$"), template: "")
+                .replace("^[ \\t]|[ \\t]$", with: "")
           matchList.append(TokenMatch(.String, match))
 
         case .Reserved:

--- a/Yaml/Tokenizer.swift
+++ b/Yaml/Tokenizer.swift
@@ -215,8 +215,8 @@ func tokenize (text: String) -> Result<[TokenMatch]> {
           let indent = (indents.last ?? 0)
           let blockPattern = regex(("^\(bBreak)( *| {\(indent),}" +
               "\(plainOutPattern))(?=\(bBreak)|$)"))
-          var block = text
-                |> substringWithRange(range)
+          var block = (text
+                |> substringWithRange(range))
                 .replace("^[ \\t]+|[ \\t]+$", with: "")
           text = text |> substringFromIndex(rangeEnd)
           while true {
@@ -233,8 +233,8 @@ func tokenize (text: String) -> Result<[TokenMatch]> {
           continue next
 
         case .StringFI:
-          let match = text
-                |> substringWithRange(range)
+          let match = (text
+                |> substringWithRange(range))
                 .replace("^[ \\t]|[ \\t]$", with: "")
           matchList.append(TokenMatch(.String, match))
 


### PR DESCRIPTION
replaced replace(regex: NSRegularExpression, template: String) with String.replace(String, with:String). It is simpler to read and compatible with linux. also added String.count for readability over count(String). related to #19 
EDIT: new commit, referenced issue