### PR TITLE
Fix missing PRODUCT_BUNDLE_IDENTIFIER on OS X targets

### DIFF
--- a/Yaml.xcodeproj/project.pbxproj
+++ b/Yaml.xcodeproj/project.pbxproj
@@ -757,6 +757,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.prosumma.Yaml;
 				PRODUCT_NAME = Yaml;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -807,6 +808,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.prosumma.Yaml;
 				PRODUCT_NAME = Yaml;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -860,6 +862,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.prosumma.Tests;
 				PRODUCT_NAME = Tests;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -904,6 +907,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.prosumma.Tests;
 				PRODUCT_NAME = Tests;
 				SDKROOT = macosx;
 			};


### PR DESCRIPTION
This fixes an issue on running `pkgbuild` https://github.com/jpsim/SourceKitten/pull/211.
```console
mkdir -p "/tmp/SourceKitten.dst/usr/local/Frameworks" "/tmp/SourceKitten.dst/usr/local/bin"
mv -f "/tmp/SourceKitten.dst/Applications/sourcekitten.app/Contents/Frameworks/SourceKittenFramework.framework" "/tmp/SourceKitten.dst/usr/local/Frameworks/SourceKittenFramework.framework"
mv -f "/tmp/SourceKitten.dst/Applications/sourcekitten.app/Contents/MacOS/sourcekitten" "/tmp/SourceKitten.dst/usr/local/bin/sourcekitten"
rm -rf "/tmp/SourceKitten.dst/Applications/sourcekitten.app"
pkgbuild \
		--component-plist "Source/sourcekitten/Components.plist" \
		--identifier "com.sourcekitten.SourceKitten" \
		--install-location "/" \
		--root "/tmp/SourceKitten.dst" \
		--version "0.12.2" \
		"SourceKitten.pkg"
pkgbuild: Reading components from Source/sourcekitten/Components.plist
pkgbuild: Adding component at usr/local/Frameworks/SourceKittenFramework.framework/Versions/A/Frameworks/Result.framework
pkgbuild: Adding component at usr/local/Frameworks/SourceKittenFramework.framework/Versions/A/Frameworks/SWXMLHash.framework
pkgbuild: Adding component at usr/local/Frameworks/SourceKittenFramework.framework/Versions/A/Frameworks/Yaml.framework
pkgbuild: Adding component at usr/local/Frameworks/SourceKittenFramework.framework/Versions/A/Frameworks/Commandant.framework
pkgbuild: Adding component at usr/local/Frameworks/SourceKittenFramework.framework
pkgbuild: error: Path "/tmp/SourceKitten.dst/usr/local/Frameworks/SourceKittenFramework.framework/Versions/A/Frameworks/Yaml.framework" is not a valid bundle component (using destination path "/tmp/SourceKitten.dst")
make: *** [package] Error 1
```
