### PR TITLE
Some refactoring for the Yaml type

### DIFF
--- a/Yaml/Yaml.swift
+++ b/Yaml/Yaml.swift
@@ -256,77 +256,27 @@ extension Yaml {
 }
 
 public func == (lhs: Yaml, rhs: Yaml) -> Bool {
-  switch lhs {
-
-  case .Null:
-    switch rhs {
-    case .Null:
-      return true
-    default:
-      return false
-    }
-
-  case .Bool(let lv):
-    switch rhs {
-    case .Bool(let rv):
-      return lv == rv
-    default:
-      return false
-    }
-
-  case .Int(let lv):
-    switch rhs {
-    case .Int(let rv):
-      return lv == rv
-    case .Double(let rv):
-      return Double(lv) == rv
-    default:
-      return false
-    }
-
-  case .Double(let lv):
-    switch rhs {
-    case .Double(let rv):
-      return lv == rv
-    case .Int(let rv):
-      return lv == Double(rv)
-    default:
-      return false
-    }
-
-  case .String(let lv):
-    switch rhs {
-    case .String(let rv):
-      return lv == rv
-    default:
-      return false
-    }
-
-  case .Array(let lv):
-    switch rhs {
-    case .Array(let rv) where lv.count == rv.count:
-      for i in 0..<lv.count {
-        if lv[i] != rv[i] {
-          return false
-        }
-      }
-      return true
-    default:
-      return false
-    }
-
-  case .Dictionary(let lv):
-    switch rhs {
-    case .Dictionary(let rv) where lv.count == rv.count:
-      for (k, v) in lv {
-        if rv[k] == nil || rv[k] != v {
-          return false
-        }
-      }
-      return true
-    default:
-      return false
-    }
+  switch (lhs, rhs) {
+  case (.Null, .Null):
+    return true
+  case (.Bool(let lv), .Bool(let rv)):
+    return lv == rv
+  case (.Int(let lv), .Int(let rv)):
+    return lv == rv
+  case (.Int(let lv), .Double(let rv)):
+    return Double(lv) == rv
+  case (.Double(let lv), .Double(let rv)):
+    return lv == rv
+  case (.Double(let lv), .Int(let rv)):
+    return lv == Double(rv)
+  case (.String(let lv), .String(let rv)):
+    return lv == rv
+  case (.Array(let lv), .Array(let rv)):
+    return lv == rv
+  case (.Dictionary(let lv), .Dictionary(let rv)):
+    return lv == rv
+  default:
+    return false
   }
 }
 

--- a/Yaml/Yaml.swift
+++ b/Yaml/Yaml.swift
@@ -280,10 +280,6 @@ public func == (lhs: Yaml, rhs: Yaml) -> Bool {
   }
 }
 
-public func != (lhs: Yaml, rhs: Yaml) -> Bool {
-  return !(lhs == rhs)
-}
-
 // unary `-` operator
 public prefix func - (value: Yaml) -> Yaml {
   switch value {

--- a/Yaml/Yaml.swift
+++ b/Yaml/Yaml.swift
@@ -48,12 +48,7 @@ extension Yaml: StringLiteralConvertible {
 
 extension Yaml: ArrayLiteralConvertible {
   public init(arrayLiteral elements: Yaml...) {
-    var array = [Yaml]()
-    array.reserveCapacity(elements.count)
-    for element in elements {
-      array.append(element)
-    }
-    self = .Array(array)
+    self = .Array(elements)
   }
 }
 

--- a/Yaml/Yaml.swift
+++ b/Yaml/Yaml.swift
@@ -129,7 +129,7 @@ extension Yaml {
       assert(index >= 0)
       switch self {
       case .Array(let array):
-        if index >= array.startIndex && index < array.endIndex {
+        if array.indices.contains(index) {
           return array[index]
         } else {
           return .Null


### PR DESCRIPTION
Most of these are minor things and I’m not sure if you like them, so feel free to not merge this or only pick the things you like. I do think the `==` function becomes clearer by switching over tuples instead of the nested switch statements. The only cases where it becomes a little tricky are `.Int` and `.Double` because they need two cases each.

The tests pass though I admit I haven’t verified whether all of the code paths I changed are executed by the tests.

As far as I can tell, these changes should have no effect on performance. I re-ran the performance tests and I did not see any discernible effect by the changes. The measured times did vary quite wildly on my machine though, so I'm not sure if that says anything. For example, in the iOS simulator the measured time fluctuated between 0.05s and 0.15s between runs (this was true on both master and on my branch).

Thanks for reading!