### PR TITLE
change bridge() to _bridgeToSwift() to compile with Swift 3.0 on Linux

### DIFF
--- a/Yaml/Regex.swift
+++ b/Yaml/Regex.swift
@@ -42,7 +42,7 @@ func replace (_ regex: NSRegularExpression, template: String) -> (String)
         _ = regex.replaceMatches(in: s, options: [], range: range,
                                  withTemplate: template)
 #if os(Linux)
-        return s.bridge()
+        return s._bridgeToSwift()
 #else
         return s as String
 #endif
@@ -76,7 +76,7 @@ func replace (_ regex: NSRegularExpression, block: @escaping ([String]) -> Strin
           }
         }
 #if os(Linux)
-        return s.bridge()
+        return s._bridgeToSwift()
 #else
         return s as String
 #endif


### PR DESCRIPTION
It'd be great if this could be included in a 2.0.1 release.