### PR TITLE
Update podspec to allow use in app extensions

### DIFF
--- a/Yaml.podspec
+++ b/Yaml.podspec
@@ -28,6 +28,9 @@ Pod::Spec.new do |s|
   s.source_files = "Yaml/*.swift"
 
   # --- Target xcconfig ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '2.3' }
+  s.pod_target_xcconfig = {
+    'SWIFT_VERSION' => '2.3',
+    'APPLICATION_EXTENSION_API_ONLY' => 'YES',
+  }
 
 end


### PR DESCRIPTION
I forgot to update the podspec in #45. This adds the app extension build setting to the podspec as well.