### PR TITLE
Rename `substringWithRange` and `substringFromIndex` to just `substring`

### DIFF
--- a/Sources/Yaml/YAMLRegex.swift
+++ b/Sources/Yaml/YAMLRegex.swift
@@ -111,16 +111,12 @@ static func splitTrail (_ regex: NSRegularExpression) -> (String)
       }
 }
 
-static func substringWithRange (_ range: NSRange) -> (String) -> String {
-  return { string in
+static func substring (_ range: NSRange, _ string : String ) -> String {
     return NSString(string: string).substring(with: range)
-  }
 }
 
-static func substringFromIndex (_ index: Int) -> (String) -> String {
-  return { string in
+static func substring (_ index: Int, _ string: String ) -> String {
     return NSString(string: string).substring(from: index)
-  }
 }
   }
 

--- a/Sources/Yaml/YAMLTokenizer.swift
+++ b/Sources/Yaml/YAMLTokenizer.swift
@@ -130,16 +130,16 @@ extension Yaml {
         for tokenPattern in tokenPatterns {
           let range = Yaml.Regex.matchRange(text, regex: tokenPattern.pattern)
           if range.location != NSNotFound {
-            let rangeend = range.location + range.length
+            let rangeEnd = range.location + range.length
             switch tokenPattern.type {
               
             case .newLine:
-              let match = text |> Yaml.Regex.substringWithRange(range)
+              let match = (range, text) |> Yaml.Regex.substring
               let lastindent = indents.last ?? 0
               let rest = match[match.index(after: match.startIndex)...]
               let spaces = rest.characters.count
               let nestedBlockSequence =
-                Yaml.Regex.matches(text |> Yaml.Regex.substringFromIndex(rangeend), regex: dashPattern!)
+                Yaml.Regex.matches((rangeEnd, text) |> Yaml.Regex.substring, regex: dashPattern!)
               if spaces == lastindent {
                 matchList.append(TokenMatch(.newLine, match))
               } else if spaces > lastindent {
@@ -165,7 +165,7 @@ extension Yaml {
               }
               
             case .dash, .questionMark:
-              let match = text |> Yaml.Regex.substringWithRange(range)
+              let match = (range, text) |> Yaml.Regex.substring
               let index = match.index(after: match.startIndex)
               let indent = match.characters.count
               indents.append((indents.last ?? 0) + indent)
@@ -180,7 +180,7 @@ extension Yaml {
               fallthrough
               
             case .colonFI:
-              let match = text |> Yaml.Regex.substringWithRange(range)
+              let match = (range, text) |> Yaml.Regex.substring
               matchList.append(TokenMatch(.colon, match))
               if insideFlow == 0 {
                 indents.append((indents.last ?? 0) + 1)
@@ -189,15 +189,15 @@ extension Yaml {
               
             case .openSB, .openCB:
               insideFlow += 1
-              matchList.append(TokenMatch(tokenPattern.type, text |> Yaml.Regex.substringWithRange(range)))
+              matchList.append(TokenMatch(tokenPattern.type, (range, text) |> Yaml.Regex.substring))
               
             case .closeSB, .closeCB:
               insideFlow -= 1
-              matchList.append(TokenMatch(tokenPattern.type, text |> Yaml.Regex.substringWithRange(range)))
+              matchList.append(TokenMatch(tokenPattern.type, (range, text) |> Yaml.Regex.substring))
               
             case .literal, .folded:
-              matchList.append(TokenMatch(tokenPattern.type, text |> Yaml.Regex.substringWithRange(range)))
-              text = text |> Yaml.Regex.substringFromIndex(rangeend)
+              matchList.append(TokenMatch(tokenPattern.type, (range, text) |> Yaml.Regex.substring))
+              text = (rangeEnd, text) |> Yaml.Regex.substring
               let lastindent = indents.last ?? 0
               let minindent = 1 + lastindent
               let blockPattern = Yaml.Regex.regex(("^(\(bBreak) *)*(\(bBreak)" +
@@ -220,26 +220,26 @@ extension Yaml {
               let indent = (indents.last ?? 0)
               let blockPattern = Yaml.Regex.regex(("^\(bBreak)( *| {\(indent),}" +
                 "\(plainOutPattern))(?=\(bBreak)|$)"))
-              var block = text
-                |> Yaml.Regex.substringWithRange(range)
+              var block = (range, text)
+                |> Yaml.Regex.substring
                 |> Yaml.Regex.replace(Yaml.Regex.regex("^[ \\t]+|[ \\t]+$"), template: "")
-              text = text |> Yaml.Regex.substringFromIndex(rangeend)
+              text = (rangeEnd, text) |> Yaml.Regex.substring
               while true {
                 let range = Yaml.Regex.matchRange(text, regex: blockPattern!)
                 if range.location == NSNotFound {
                   break
                 }
-                let s = text |> Yaml.Regex.substringWithRange(range)
+                let s = (range, text) |> Yaml.Regex.substring
                 block += "\n" +
                   Yaml.Regex.replace(Yaml.Regex.regex("^\(bBreak)[ \\t]*|[ \\t]+$"), template: "")(s)
-                text = text |> Yaml.Regex.substringFromIndex(range.location + range.length)
+                text = (range.location + range.length, text) |> Yaml.Regex.substring
               }
               matchList.append(TokenMatch(.string, block))
               continue next
               
             case .stringFI:
-              let match = text
-                |> Yaml.Regex.substringWithRange(range)
+              let match = (range, text)
+                |> Yaml.Regex.substring
                 |> Yaml.Regex.replace(Yaml.Regex.regex("^[ \\t]|[ \\t]$"), template: "")
               matchList.append(TokenMatch(.string, match))
               
@@ -247,9 +247,9 @@ extension Yaml {
               return fail(escapeErrorContext(text))
               
             default:
-              matchList.append(TokenMatch(tokenPattern.type, text |> Yaml.Regex.substringWithRange(range)))
+              matchList.append(TokenMatch(tokenPattern.type, (range, text) |> Yaml.Regex.substring))
             }
-            text = text |> Yaml.Regex.substringFromIndex(rangeend)
+            text = (rangeEnd, text) |> Yaml.Regex.substring
             continue next
           }
         }

--- a/Sources/Yaml/YAMLTokenizer.swift
+++ b/Sources/Yaml/YAMLTokenizer.swift
@@ -2,7 +2,7 @@ import Foundation
 
 
 extension Yaml {
-  enum TokenType: Swift.String {
+  enum TokenType: String {
     case yamlDirective = "%YAML"
     case docStart = "doc-start"
     case docend = "doc-end"

--- a/Sources/Yaml/Yaml.swift
+++ b/Sources/Yaml/Yaml.swift
@@ -2,10 +2,10 @@ import Foundation
 
 public enum Yaml {
   case null
-  case bool(Swift.Bool)
-  case int(Swift.Int)
-  case double(Swift.Double)
-  case string(Swift.String)
+  case bool(Bool)
+  case int(Int)
+  case double(Double)
+  case string(String)
   case array([Yaml])
   case dictionary([Yaml: Yaml])
     
@@ -108,7 +108,7 @@ extension Yaml: ExpressibleByDictionaryLiteral {
 }
 
 extension Yaml: CustomStringConvertible {
-  public var description: Swift.String {
+  public var description: String {
     switch self {
     case .null:
       return "Null"
@@ -129,7 +129,7 @@ extension Yaml: CustomStringConvertible {
 }
 
 extension Yaml: Hashable {
-  public var hashValue: Swift.Int {
+  public var hashValue: Int {
     return description.hashValue
   }
 }
@@ -138,18 +138,18 @@ extension Yaml: Hashable {
 
 extension Yaml {
   
-  public static func load (_ text: Swift.String) throws -> Yaml {
+  public static func load (_ text: String) throws -> Yaml {
     let result = tokenize(text) >>=- Context.parseDoc
     if let value = result.value { return value } else { throw ResultError.message(result.error) }
   }
 
-  public static func loadMultiple (_ text: Swift.String) throws -> [Yaml] {
+  public static func loadMultiple (_ text: String) throws -> [Yaml] {
     let result = tokenize(text) >>=- Context.parseDocs
     if let value = result.value { return value } else { throw ResultError.message(result.error) }
 
   }
 
-  public static func debug (_ text: Swift.String) -> Yaml? {
+  public static func debug (_ text: String) -> Yaml? {
     let result = tokenize(text)
         >>- { tokens in print("\n====== Tokens:\n\(tokens)"); return tokens }
         >>=- Context.parseDoc
@@ -160,7 +160,7 @@ extension Yaml {
     return result.value
   }
 
-  public static func debugMultiple (_ text: Swift.String) -> [Yaml]? {
+  public static func debugMultiple (_ text: String) -> [Yaml]? {
     let result = tokenize(text)
         >>- { tokens in print("\n====== Tokens:\n\(tokens)"); return tokens }
         >>=- Context.parseDocs
@@ -175,7 +175,7 @@ extension Yaml {
 }
 
 extension Yaml {
-  public subscript(index: Swift.Int) -> Yaml {
+  public subscript(index: Int) -> Yaml {
     get {
       assert(index >= 0)
       switch self {
@@ -232,7 +232,7 @@ extension Yaml {
 }
 
 extension Yaml {
-  public var bool: Swift.Bool? {
+  public var bool: Bool? {
     switch self {
     case .bool(let b):
       return b
@@ -241,13 +241,13 @@ extension Yaml {
     }
   }
 
-  public var int: Swift.Int? {
+  public var int: Int? {
     switch self {
     case .int(let i):
       return i
     case .double(let f):
-      if Swift.Double(Swift.Int(f)) == f {
-        return Swift.Int(f)
+      if Double(Int(f)) == f {
+        return Int(f)
       } else {
         return nil
       }
@@ -256,18 +256,18 @@ extension Yaml {
     }
   }
 
-  public var double: Swift.Double? {
+  public var double: Double? {
     switch self {
     case .double(let f):
       return f
     case .int(let i):
-      return Swift.Double(i)
+      return Double(i)
     default:
       return nil
     }
   }
 
-  public var string: Swift.String? {
+  public var string: String? {
     switch self {
     case .string(let s):
       return s
@@ -294,7 +294,7 @@ extension Yaml {
     }
   }
 
-  public var count: Swift.Int? {
+  public var count: Int? {
     switch self {
     case .array(let array):
       return array.count


### PR DESCRIPTION
* Removing nested closure to just using the function signature directly.

In the future, might switch out `NSString` to `String`, `substring` to the `subscription []` operator and `NSRange` to `Range<Int>` or `Range<String.Index>`

Any takes on this? 