### PR TITLE
Add swift_version directly to podspec

### DIFF
--- a/Yaml.podspec
+++ b/Yaml.podspec
@@ -1,14 +1,15 @@
 Pod::Spec.new do |s|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.name         = "Yaml"
-  s.version      = "3.4.1"
-  s.summary      = "Load YAML and JSON documents using Swift"
-  s.description  = <<-DESC
-                YamlSwift parses a string of YAML document(s) (or a JSON document)
-                and returns a Yaml enum value representing that string.
+  s.name          = "Yaml"
+  s.version       = "3.4.1"
+  s.summary       = "Load YAML and JSON documents using Swift"
+  s.description   = <<-DESC
+                 YamlSwift parses a string of YAML document(s) (or a JSON document)
+                 and returns a Yaml enum value representing that string.
                    DESC
-  s.homepage     = "https://github.com/behrang/YamlSwift"
+  s.homepage      = "https://github.com/behrang/YamlSwift"
+  s.swift_version = "4.0"
 
   # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.license      = "MIT"


### PR DESCRIPTION
- Adding the xcconfig option isn't enough here, since the default appears to be Swift 3.2
- Without this change, after a pod install, the target looks like this:

<img width="678" alt="screen shot 2018-03-02 at 11 33 31 am" src="https://user-images.githubusercontent.com/2645146/36918100-90f50744-1e0d-11e8-9261-284a87531f31.png">
