### PR TITLE
Add flag for preserving comments when parsing file

### DIFF
--- a/Sources/Yaml/YAMLParser.swift
+++ b/Sources/Yaml/YAMLParser.swift
@@ -51,8 +51,7 @@ struct Context {
                     foundComment = false
 
                     for token in updatedTokens {
-                        if case let (type: type, match: comment) = token, type == Yaml.TokenType.comment {
-                            print("comment token = ", token)
+                        if case let (type: type, match: comment) = token, type == Yaml.TokenType.comment, let unwrappedCommentText = Context.getCommentText(comment) {
                             // print(Context.getCommentText(comment)!, lastString)
                             newEntries.append(
                                 contentsOf: [
@@ -60,7 +59,7 @@ struct Context {
                                     (type: Yaml.TokenType.colon, match: ":"),
                                     (type: Yaml.TokenType.indent, match: ""),
                                     (type: Yaml.TokenType.space, match: " "),
-                                    (type: Yaml.TokenType.string, match: Context.getCommentText(comment)!),
+                                    (type: Yaml.TokenType.string, match: unwrappedCommentText),
                                     (type: Yaml.TokenType.dedent, match: ""),
                                     (type: Yaml.TokenType.newLine, match: "\n    ")
                                 ]

--- a/Sources/Yaml/YAMLParser.swift
+++ b/Sources/Yaml/YAMLParser.swift
@@ -52,6 +52,7 @@ struct Context {
 
                     for token in updatedTokens {
                         if case let (type: type, match: comment) = token, type == Yaml.TokenType.comment {
+                            print("comment token = ", token)
                             // print(Context.getCommentText(comment)!, lastString)
                             newEntries.append(
                                 contentsOf: [

--- a/Sources/Yaml/YAMLParser.swift
+++ b/Sources/Yaml/YAMLParser.swift
@@ -52,10 +52,9 @@ struct Context {
 
                     for token in updatedTokens {
                         if case let (type: type, match: comment) = token, type == Yaml.TokenType.comment, let unwrappedCommentText = Context.getCommentText(comment) {
-                            // print(Context.getCommentText(comment)!, lastString)
                             newEntries.append(
                                 contentsOf: [
-                                    (type: Yaml.TokenType.string, match: "__comment__\(lastString)"),
+                                    (type: Yaml.TokenType.string, match: "\(Yaml.commentPrefix)\(lastString)"),
                                     (type: Yaml.TokenType.colon, match: ":"),
                                     (type: Yaml.TokenType.indent, match: ""),
                                     (type: Yaml.TokenType.space, match: " "),
@@ -74,23 +73,16 @@ struct Context {
                         i += 1
                     }
 
-                    // print(newEntries)
-                    // print(lastStringIndex)
-
                     if (foundComment) {
                         updatedTokens.remove(at: commentIndex)
                         updatedTokens.insert(contentsOf: newEntries, at: lastStringIndex)
-                        // print(updatedTokens)
                     }
 
-                    // break
                 }
 
             }
 
             let cv = .value(Context(updatedTokens, updatedAliases)) >>=- parse
-            // print(cv)
-            // print()
             let v = cv >>- getValue
             return cv
               >>- getContext
@@ -99,16 +91,7 @@ struct Context {
               >>| v
         }
 
-        // print("upd")
-        // print(updatedTokens)
-
-        // print("------------------")
-        // print()
-        // print(header)
-        // print()
         let cv = header >>=- parse
-        // print(cv)
-        // print()
         let v = cv >>- getValue
         return cv
           >>- getContext

--- a/Sources/Yaml/Yaml.swift
+++ b/Sources/Yaml/Yaml.swift
@@ -45,6 +45,17 @@ public enum Yaml: Hashable {
             fatalError("`-` operator may only be used on .int or .double Yaml values")
         }
     }
+
+    public static let commentPrefix = "__comment__"
+
+    public func getComment(forKey key: String) -> String? {
+        switch self[.string("\(Yaml.commentPrefix)\(key)")] {
+            case let .string(value):
+                return value
+            default:
+                return nil
+        }
+    }
 }
 
 extension Yaml {

--- a/Sources/Yaml/Yaml.swift
+++ b/Sources/Yaml/Yaml.swift
@@ -131,8 +131,8 @@ extension Yaml: CustomStringConvertible {
 
 extension Yaml {
   
-  public static func load (_ text: String) throws -> Yaml {
-    let result = tokenize(text) >>=- Context.parseDoc
+  public static func load (_ text: String, preserveComments: Bool = false) throws -> Yaml {
+    let result = tokenize(text) >>=- Context.makeDocParser(preserveComments: preserveComments)
     if let value = result.value { return value } else { throw ResultError.message(result.error) }
   }
 
@@ -145,7 +145,7 @@ extension Yaml {
   public static func debug (_ text: String) -> Yaml? {
     let result = tokenize(text)
         >>- { tokens in print("\n====== Tokens:\n\(tokens)"); return tokens }
-        >>=- Context.parseDoc
+        >>=- Context.makeDocParser()
         >>- { value -> Yaml in print("------ Doc:\n\(value)"); return value }
     if let error = result.error {
       print("~~~~~~\n\(error)")

--- a/Tests/YamlTests/ExampleTests.swift
+++ b/Tests/YamlTests/ExampleTests.swift
@@ -55,28 +55,18 @@ class ExampleTests: XCTestCase {
     let value = try! Yaml.load(
         """
         foo:
-            bar:  # quux
+            bar: # quux
                 - baz
                 - qux
         """,
         preserveComments: true
       )
 
-    // print(value == Yaml.dictionary([.string("foo"): .string("bar")]))
-
-    XCTAssertEqual(value["foo"]["__comment__bar"], "quux")
-
-    // XCTAssert(
-    //     NSDictionary(
-    //         dictionary: value
-    //     ).isEqual(
-    //         to: ["foo": ["bar": ["baz": ["qux", "quux"]]]]
-    //     ), "Expected and loaded dictionaries are not the same"
-    // )
-    // XCTAssert(value.count == 3)
-    // XCTAssert(value["avg"] == 0.278)
+    // XCTAssertEqual(value["foo"]["__comment__bar"], "quux")
+    // print(value["foo"].getComment(forKey: "bar"))
+    XCTAssertEqual(value["foo"].getComment(forKey: "bar"), "quux")
   }
-  
+
   func testExample3 () {
     let value = try! Yaml.load(
       "american:\n" +

--- a/Tests/YamlTests/ExampleTests.swift
+++ b/Tests/YamlTests/ExampleTests.swift
@@ -62,8 +62,6 @@ class ExampleTests: XCTestCase {
         preserveComments: true
       )
 
-    // XCTAssertEqual(value["foo"]["__comment__bar"], "quux")
-    // print(value["foo"].getComment(forKey: "bar"))
     XCTAssertEqual(value["foo"].getComment(forKey: "bar"), "quux")
   }
 

--- a/Tests/YamlTests/ExampleTests.swift
+++ b/Tests/YamlTests/ExampleTests.swift
@@ -50,6 +50,32 @@ class ExampleTests: XCTestCase {
     XCTAssert(value.count == 3)
     XCTAssert(value["avg"] == 0.278)
   }
+
+  func testComment() {
+    let value = try! Yaml.load(
+        """
+        foo:
+            bar:  # quux
+                - baz
+                - qux
+        """,
+        preserveComments: true
+      )
+
+    // print(value == Yaml.dictionary([.string("foo"): .string("bar")]))
+
+    XCTAssertEqual(value["foo"]["__comment__bar"], "quux")
+
+    // XCTAssert(
+    //     NSDictionary(
+    //         dictionary: value
+    //     ).isEqual(
+    //         to: ["foo": ["bar": ["baz": ["qux", "quux"]]]]
+    //     ), "Expected and loaded dictionaries are not the same"
+    // )
+    // XCTAssert(value.count == 3)
+    // XCTAssert(value["avg"] == 0.278)
+  }
   
   func testExample3 () {
     let value = try! Yaml.load(
@@ -490,6 +516,7 @@ extension ExampleTests {
       ("testExample20", testExample20),
       ("testExample21", testExample21),
       ("testExample22", testExample22),
+      ("testComment", testComment),
       ("testYamlHomepage", testYamlHomepage),
       ("testPerformanceExample", testPerformanceExample),
     ]


### PR DESCRIPTION
Current version discards any space characters and comments, however comments sometimes contain useful information, so there is a simple change which allows to preserve comments written on the same line as a key